### PR TITLE
Feature/cors policy updated

### DIFF
--- a/myapi/settings.py
+++ b/myapi/settings.py
@@ -48,6 +48,7 @@ INSTALLED_APPS = [
     # Third-Party Apps
     'rest_framework',
     'rest_framework.authtoken',
+    'corsheaders',
 
     # Local Apps (Your project's apps)
     'myapi.core',
@@ -56,6 +57,7 @@ INSTALLED_APPS = [
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
@@ -143,3 +145,7 @@ REST_FRAMEWORK = {
 }
 
 AUTH_USER_MODEL = 'core.CustomUser'
+
+CORS_ALLOWED_ORIGINS = [
+    'http://localhost:3000',
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 django==4.0.3
 djangorestframework==3.13.1
 python-dotenv==0.20.0
+django-cors-headers==3.11.0


### PR DESCRIPTION
Updated settings to allow CORS policy to approve calls from our frontend APP currently running from 127.0.0.1:3000 ie. react default